### PR TITLE
Add Chakra formula

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ before_install:
   - rm -rfv "${HOMEBREW_TAP_DIR}"
   - ln -s "${PWD}" "${HOMEBREW_TAP_DIR}"
   - export HOMEBREW_DEVELOPER="1"
+  - ulimit -n 1024
 
 script:
-  - brew test-bot
+  - brew test-bot --no-bottle
+git:
+  depth: 1

--- a/Formula/chakra.rb
+++ b/Formula/chakra.rb
@@ -1,0 +1,16 @@
+class Chakra < Formula
+  desc "The core part of the Chakra JavaScript engine that powers Microsoft Edge"
+  homepage "https://github.com/Microsoft/ChakraCore"
+  url "https://aka.ms/chakracore/cc_osx_x64_1_5_1"
+  sha256 "8e85cfc21a693ae1b02373228a3a921485aa6567faa97dcdb904e030632b908b"
+
+  def install
+    lib.install "lib/libChakraCore.dylib"
+    bin.install "bin/ch" => "chakra"
+  end
+
+  test do
+    (testpath/"test.js").write("print('Hello!');\n")
+    assert_equal "Hello!", shell_output("#{bin}/chakra test.js").chomp
+  end
+end


### PR DESCRIPTION
@obastemur This is what I had in mind. What do you think?

This way, OS X users could install the `chakra` binary by running `brew install mathiasbynens/ecmascript/chakra`.

I plan to merge this once ~~v2.0.0~~ the next version is officially released. Updating the formula when ChakraCore updates is a matter of updating the `url` and `sha256` properties in this file. I’m hoping this could be made part of the ChakraCore release process, or even automated in some way.